### PR TITLE
Create Makefile.osx_m1

### DIFF
--- a/Makefile.osx_m1
+++ b/Makefile.osx_m1
@@ -1,4 +1,4 @@
-# EMWM generic Makefile
+# EMWM Mac OSX Makefile
 
 PREFIX = /usr
 MANDIR = $(PREFIX)/share/man


### PR DESCRIPTION
Make this compatible with Mac OSX on apple silicon with the assumption of homebrew installing the motif libraries. Learned the hard way of how motif links on macs from https://github.com/justinmeiners/classic-colors/issues/8
<img width="1680" alt="Screen Shot 2021-10-23 at 8 17 46 PM" src="https://user-images.githubusercontent.com/53055079/138576193-0599c260-fec5-443a-820b-6b9610889576.png">

