### PR TITLE
use DESTDIR in Makefile

### DIFF
--- a/src/common.mf
+++ b/src/common.mf
@@ -41,18 +41,19 @@ clean:
 	-rm .depend
 
 common_install:
-	install -m 775 emwm $(PREFIX)/bin/emwm
-	install -m 775 -d $(MANDIR)/man1
-	install -m 664 emwm.1 $(MANDIR)/man1/emwm.1
-	install -m 775 -d $(RCDIR)
-	install -m 664 system.emwmrc $(RCDIR)/system.emwmrc
-	install -m 775 -d $(APPLRESDIR)
-	install -m 664 Emwm.ad $(APPLRESDIR)/Emwm
+	install -m 775 -d $(DESTDIR)$(PREFIX)/bin
+	install -m 775 emwm $(DESTDIR)$(PREFIX)/bin/emwm
+	install -m 775 -d $(DESTDIR)$(MANDIR)/man1
+	install -m 664 emwm.1 $(DESTDIR)$(MANDIR)/man1/emwm.1
+	install -m 775 -d $(DESTDIR)$(RCDIR)
+	install -m 664 system.emwmrc $(DESTDIR)$(RCDIR)/system.emwmrc
+	install -m 775 -d $(DESTDIR)$(APPLRESDIR)
+	install -m 664 Emwm.ad $(DESTDIR)$(APPLRESDIR)/Emwm
 
 uninstall:
-	rm -f $(PREFIX)/bin/emwm
-	rm -f $(MANDIR)/man1/emwm.1
-	rm -f $(RCDIR)/system.emwmrc
-	rmdir $(RCDIR)
-	rm -f $(APPLRESDIR)/Emwm
+	rm -f $(DESTDIR)$(PREFIX)/bin/emwm
+	rm -f $(DESTDIR)$(MANDIR)/man1/emwm.1
+	rm -f $(DESTDIR)$(RCDIR)/system.emwmrc
+	rmdir $(DESTDIR)$(RCDIR)
+	rm -f $(DESTDIR)$(APPLRESDIR)/Emwm
 


### PR DESCRIPTION
I wish to package this program for a distribution, and the build system for said distribution requires that package files are placed in a custom destination directory. it's [general makefile convention](https://www.gnu.org/software/make/manual/html_node/Makefile-Conventions.html) to use `DESTDIR` in `install` and `uninstall` for staged installs such as this, and doing this shouldn't affect the normal way of compiling and installing on all operating systems.